### PR TITLE
Fix for 'undefined' getMarkers property.

### DIFF
--- a/lib/fold-lines.coffee
+++ b/lib/fold-lines.coffee
@@ -7,7 +7,7 @@ module.exports = FoldLines =
     @subscriptions = new CompositeDisposable
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
-      foldsLayer = editor.displayBuffer.foldsMarkerLayer
+      foldsLayer = editor.displayLayer.foldsMarkerLayer
 
       # Handle current folds.
       markers = foldsLayer.getMarkers()


### PR DESCRIPTION
DisplayBuffer changed to DisplayLayer in TextEditor object.

https://github.com/alysov/fold-lines/issues/4
